### PR TITLE
Potential fix for code scanning alert no. 11: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/build_linux.yml
+++ b/.github/workflows/build_linux.yml
@@ -17,6 +17,8 @@ on:
         required: true
         type: string
 
+permissions:
+  contents: read
 jobs:
   build:
     runs-on: ubuntu-22.04

--- a/.github/workflows/build_windows.yml
+++ b/.github/workflows/build_windows.yml
@@ -1,4 +1,6 @@
 name: Build Windows
+permissions:
+  contents: read
 
 on:
   workflow_call:

--- a/.github/workflows/pushed.yml
+++ b/.github/workflows/pushed.yml
@@ -1,4 +1,6 @@
 name: Pushed
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/LordOfDragons/dragonscript/security/code-scanning/11](https://github.com/LordOfDragons/dragonscript/security/code-scanning/11)

To fix the problem, you should explicitly add a `permissions:` block to the `.github/workflows/pushed.yml` workflow file, at the root level (before `jobs:`), to enforce least privilege access for the GITHUB_TOKEN. This will ensure no jobs in this workflow inherit overly broad repository or organizational permissions. The safest minimal starting point is typically `contents: read`, which allows jobs to check out code but not to write or modify repository contents. You can later add specific permissions as needed for tasks like creating releases, updating PRs, etc., but unless required by the jobs called, keep it minimal.

Specifically, insert:

```yaml
permissions:
  contents: read
```

after the workflow `name:` and before `on:` (e.g., between lines 1 and 3). No additional imports or external dependencies are necessary; this is fully within the YAML workflow.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
